### PR TITLE
Update VectorVsKG.ipynb

### DIFF
--- a/VectorVsKG.ipynb
+++ b/VectorVsKG.ipynb
@@ -1387,11 +1387,11 @@
     "\n",
     "# Example usage with the provided URI\n",
     "article_uri = \"http://example.org/article/Expression_of_p53_and_coexistence_of_HPV_in_premalignant_lesions_and_in_cervical_cancer.\"\n",
-    "mesh_terms = get_mesh_terms_for_article(g, article_uri)\n",
+    "mesh_terms_example = get_mesh_terms_for_article(g, article_uri)\n",
     "\n",
     "# Output the results\n",
     "print(f\"MeSH terms associated with the article '{article_uri}':\")\n",
-    "for term in mesh_terms:\n",
+    "for term in mesh_terms_example:\n",
     "    print(term)\n"
    ]
   },


### PR DESCRIPTION
In line 1390, the cell accidentally overwrites the previous "mesh_terms", which has URIRefs and may be expected to be the input values for the following "Similarity search with vectorized KG" section. However, the "mesh_terms" of line 1390 has no URIRefs and got an error when I ran the code in the following section.